### PR TITLE
[WIP] fix: JSSHAPE_HASH_OFFSET macro

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -854,7 +854,7 @@ typedef struct JSShapeProperty {
 #ifdef _MSC_VER
 #define JSSHAPE_HASH_OFFSET(ptr, offset) (((uint32_t *)(ptr))+(offset))
 #else
-#define JSSHAPE_HASH_OFFSET(ptr, offset) ((ptr)->prop_hash_end[offset])
+#define JSSHAPE_HASH_OFFSET(ptr, offset) (&(ptr)->prop_hash_end[offset])
 #endif
 
 struct JSShape {

--- a/quickjs.c
+++ b/quickjs.c
@@ -1680,7 +1680,7 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
     if (init_shape_hash(rt))
         goto fail;
 
-    rt->stack_top = _alloca(0);
+    rt->stack_top = NULL;
     rt->stack_size = JS_DEFAULT_STACK_SIZE;
     rt->current_exception = JS_NULL;
 


### PR DESCRIPTION
### Build log
```
====================[ Build | quickjs_interpreter | Debug ]=====================
/Applications/CLion.app/Contents/bin/cmake/mac/bin/cmake --build /Users/edward/github/SASUKE40/QuickJS/cmake-build-debug --target quickjs_interpreter -- -j 8
[ 77%] Built target quickjs
[ 88%] Linking C executable quickjs_interpreter
Undefined symbols for architecture x86_64:
  "__alloca", referenced from:
      _JS_NewRuntime2 in libquickjs.a(quickjs.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [interpreter/quickjs_interpreter] Error 1
make[2]: *** [interpreter/CMakeFiles/quickjs_interpreter.dir/all] Error 2
make[1]: *** [interpreter/CMakeFiles/quickjs_interpreter.dir/rule] Error 2
make: *** [quickjs_interpreter] Error 2
```